### PR TITLE
Add access to client

### DIFF
--- a/aas_http_client/wrapper/sdk_wrapper.py
+++ b/aas_http_client/wrapper/sdk_wrapper.py
@@ -288,8 +288,15 @@ class SdkWrapper:
         """
         return self._client.patch_submodel_element_by_path_value_only_submodel_repo(submodel_id, submodel_element_path, value)
 
+    # endregion
 
-# endregion
+    def get_client(self) -> AasHttpClient:
+        """Returns the underlying AAS HTTP client.
+
+        :return: The AAS HTTP client instance.
+        """
+        return self._client
+
 
 # region utils
 

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -90,6 +90,12 @@ def test_000b_create_wrapper_by_dict(wrapper: SdkWrapper):
     new_client: SdkWrapper = create_wrapper_by_dict(configuration=config_dict)
     assert new_client is not None
 
+def test_000c_get_client(wrapper: SdkWrapper):
+    client = wrapper.get_client()
+    assert client is not None
+    root = client.get_root()
+    assert root is not None
+
 def test_001_connect(wrapper: SdkWrapper):
     assert wrapper is not None
 


### PR DESCRIPTION
Add wrapper method to retrieve the underlying element. This allows client methods to also be called via the wrapper.